### PR TITLE
Correct type names for Channels Swift code snippets

### DIFF
--- a/docs/channels/using_channels/events.md
+++ b/docs/channels/using_channels/events.md
@@ -79,9 +79,9 @@ channel.bind("new-comment", handler, context);
 ```
 
 {% endparameter %}
-{% parameter 'PTPusherChannel', 'String', true, 'swift', false %}
+{% parameter 'PusherChannel', 'String', true, 'swift', false %}
 
-Once you have created an instance of PTPusherChannel, you can set up event bindings. There is no need to wait for the PTPusher client connection to be established.
+Once you have created an instance of `PusherChannel`, you can set up event bindings. There is no need to wait for the `PusherSwift` client connection to be established.
 
 When you bind to events on a single channel, you will only receive events with that name if they are sent over this channel.
 
@@ -163,9 +163,9 @@ pusher.bind(eventName, callback);
 
 A function to be called whenever the event is triggered.
 {% endparameter %}
-{% parameter 'PTPusher', 'PTPusher', true, 'swift', false %}
+{% parameter 'PusherSwift', 'PusherSwift', true, 'swift', false %}
 
-Once you have created an instance of the `PTPusher` client, you can set up event bindings. There is no need to wait for the connection to be established.
+Once you have created an instance of the `PusherSwift` client, you can set up event bindings. There is no need to wait for the connection to be established.
 
 When you bind to events on the client, you will receive all events with that name, regardless of the channel from which they originated.
 
@@ -270,7 +270,7 @@ channel.unbind();
 ```
 
 {% endparameter %}
-{% parameter 'binding', 'PTPusherEventBinding', true, 'swift', false %}
+{% parameter 'binding', 'String', false, 'swift', false %}
 
 Represents the binding to be removed.
 

--- a/docs/channels/using_channels/presence-channels.md
+++ b/docs/channels/using_channels/presence-channels.md
@@ -59,8 +59,6 @@ The name of the channel to subscribe to. Since it is a presence channel the name
 
 An object which events can be bound to. See [binding to events](/docs/channels/using_channels/events#binding-to-events) for more information.
 
-> It is recommended to implement `PTPusherPresenceChannelDelegate` protocol, to receive notifications for members subscribing or unsubscribing from the presence channel.
-
 {% endparameter %}
 {% endmethodwrap %}
 

--- a/docs/channels/using_channels/private-channels.md
+++ b/docs/channels/using_channels/private-channels.md
@@ -40,13 +40,13 @@ The name of the channel to subscribe to. Since it is a private channel the name 
 A `Channel` object which events can be bound to. See [binding to events](/docs/channels/using_channels/events#binding-to-events) for more information on the `Channel` object.
 
 {% endparameter %}
-{% parameter 'privateChannelName', "String", true, 'swift', false %}
+{% parameter 'channelName', "String", true, 'swift', false %}
 
-The name of the channel to subscribe to. _This method will add the appropriate `private-` prefix to the channel name for you_.
+The name of the channel to subscribe to. Since it is a private channel the name must be prefixed with `private-`
 
 ##### Returns
 
-A channel cast to the correct `PTPusherChannel` subclass `PTPusherPrivateChannel` which events can be bound to. See [binding to events](/docs/channels/using_channels/events#binding-to-events).
+A `PusherChannel` object which events can be bound to. See [binding to events](/docs/channels/using_channels/events#binding-to-events).
 
 {% endparameter %}
 {% endmethodwrap %}

--- a/docs/channels/using_channels/public-channels.md
+++ b/docs/channels/using_channels/public-channels.md
@@ -71,7 +71,7 @@ The name of the channel to unsubscribe from.
 
 {% endparameter %}
 
-{% parameter 'channel', 'PTPusherChannel', true, 'swift', false %}
+{% parameter 'channelName', 'String', true, 'swift', false %}
 
 The name of the channel to unsubscribe from.
 


### PR DESCRIPTION
This PR:

- Corrects some errors with Swift type names for the Channels SDK.
- Removes redundant comments.