### PR TITLE
Replace outdated slugify function with one that’s maintained

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -2,8 +2,8 @@ const fs = require("fs");
 const eleventyNavigationPlugin = require("@11ty/eleventy-navigation");
 const pluginTOC = require("eleventy-plugin-toc");
 const pluginSyntaxHighlight = require("@11ty/eleventy-plugin-syntaxhighlight");
-const stringLib = require("string");
-const slugifyCustom = (s) => stringLib(s).slugify().toString();
+const slugify = require("slugify");
+const slugifyCustom = (s) => slugify(s);
 const hash = (s) =>
   s.split("").reduce((a, b) => {
     a = (a << 5) - a + b.charCodeAt(0);

--- a/package.json
+++ b/package.json
@@ -30,11 +30,11 @@
     "postcss-flexbugs-fixes": "^5.0.2",
     "postcss-import": "^14.0.0",
     "postcss-nested": "^5.0.5",
-    "postcss-preset-env": "^6.7.0",
-    "string": "^3.3.3"
+    "postcss-preset-env": "^6.7.0"
   },
   "dependencies": {
     "algoliasearch": "^4.8.6",
-    "isomorphic-dompurify": "^0.13.0"
+    "isomorphic-dompurify": "^0.13.0",
+    "slugify": "^1.5.0"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -4069,7 +4069,7 @@ slash@^3.0.0:
   resolved "https://registry.yarnpkg.com/slash/-/slash-3.0.0.tgz#6539be870c165adbd5240220dbe361f1bc4d4634"
   integrity sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==
 
-slugify@^1.4.7:
+slugify@^1.4.7, slugify@^1.5.0:
   version "1.5.0"
   resolved "https://registry.yarnpkg.com/slugify/-/slugify-1.5.0.tgz#5f3c8e2a84105b54eb51486db1b468a599b3c9b8"
   integrity sha512-Q2UPZ2udzquy1ElHfOLILMBMqBEXkiD3wE75qtBvV+FsDdZZjUqPZ44vqLTejAVq+wLLHacOMcENnP8+ZbzmIA==
@@ -4197,11 +4197,6 @@ string-width@^4.1.0, string-width@^4.2.0:
     emoji-regex "^8.0.0"
     is-fullwidth-code-point "^3.0.0"
     strip-ansi "^6.0.0"
-
-string@^3.3.3:
-  version "3.3.3"
-  resolved "https://registry.yarnpkg.com/string/-/string-3.3.3.tgz#5ea211cd92d228e184294990a6cc97b366a77cb0"
-  integrity sha1-XqIRzZLSKOGEKUmQpsyXs2anfLA=
 
 strip-ansi@^3.0.0:
   version "3.0.1"


### PR DESCRIPTION
The risk was low as it was only used at build time but not good to use
well old package