### PR TITLE
Remove the BETA label from the Channels Swift server library links

### DIFF
--- a/docs/channels/channels_libraries/libraries.md
+++ b/docs/channels/channels_libraries/libraries.md
@@ -47,7 +47,7 @@ The following libraries are updated and supported by Pusher.
 | PHP     | Pusher     | [Docs](https://github.com/pusher/pusher-http-php#installation)                 | [pusher/pusher-http-php](https://github.com/pusher/pusher-http-php)       |
 | Python  | Pusher     | [Docs](https://github.com/pusher/pusher-http-python#installation)              | [pusher/pusher-http-python](http://github.com/pusher/pusher-http-python)  |
 | Ruby    | Pusher     | [Docs](https://github.com/pusher/pusher-http-ruby#installation--configuration) | [pusher/pusher-http-ruby](https://github.com/pusher/pusher-http-ruby)     |
-| Swift [[BETA](https://pusher.com/docs/lab#beta-features)] | Pusher  | [Docs](https://github.com/pusher/pusher-http-swift#installation)  | [pusher/pusher-http-swift](https://github.com/pusher/pusher-http-swift) |
+| Swift   | Pusher     | [Docs](https://github.com/pusher/pusher-http-swift#installation)               | [pusher/pusher-http-swift](https://github.com/pusher/pusher-http-swift)   |
 
 # Community libraries
 

--- a/docs/lab/index.md
+++ b/docs/lab/index.md
@@ -42,7 +42,6 @@ Typically beta features will remain beta for no longer than two business quarter
 | Product | Feature                       | Last update | Review by date | Resources                                                                       | Status |
 | ------- | ----------------------------- | ----------- | -------------- | ------------------------------------------------------------------------------- | ------ |
 | Beams   | Safari web push notifications | 26 Mar 2021 | 26 May 2021    | [Safari configuration guide](/docs/beams/getting-started/web/configure-safari/) | Active |
-| Channels  | Swift HTTP API library | 25 May 2021 | 22 Jun 2021 | [Docs](https://github.com/pusher/pusher-http-swift#installation) | Active  |
 
 ## Communication
 


### PR DESCRIPTION
As per title.