### PR TITLE
Remove /accounts/sign_in from Sign In link

### DIFF
--- a/_includes/partials/top-nav.njk
+++ b/_includes/partials/top-nav.njk
@@ -75,7 +75,7 @@
           </div>
         </li>
         <li class="ml-auto">
-          <a href="https://dashboard.pusher.com/accounts/sign_in" rel="noreferrer" class="db maison f7 fw6 link eggplant hover-dragonfruit">
+          <a href="https://dashboard.pusher.com/" rel="noreferrer" class="db maison f7 fw6 link eggplant hover-dragonfruit">
             Sign&nbsp;in
           </a>
         </li>


### PR DESCRIPTION
Going to https://dashboard.pusher.com redirects you to sign in if you aren't logged in, otherwise you're taken to the logged in dashboard. Previously, going to /accounts/sign_in would redirect you to a JSON stats endpoint