### PR TITLE
clicking search results in safari doesn't work

### DIFF
--- a/css/modules/_search.pcss
+++ b/css/modules/_search.pcss
@@ -7,7 +7,7 @@
 }
 
 #search-results-wrap:active {
-  dispaly: block;
+  display: block;
 }
   
 #search-results li + li {

--- a/css/modules/_search.pcss
+++ b/css/modules/_search.pcss
@@ -6,6 +6,10 @@
   display: none;
 }
 
+#search-results-wrap:active {
+  dispaly: bock;
+}
+  
 #search-results li + li {
   border-top: 1px solid var(--smoke);
 }

--- a/css/modules/_search.pcss
+++ b/css/modules/_search.pcss
@@ -7,7 +7,7 @@
 }
 
 #search-results-wrap:active {
-  dispaly: bock;
+  dispaly: block;
 }
   
 #search-results li + li {


### PR DESCRIPTION
the focus-within on search wrap looses focus before the link event. Adding wrap:active seems to fix it.