### PR TITLE
Use namespace for package name

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "pusher-docs",
+  "name": "@pusher/docs",
   "version": "1.0.0",
   "main": "index.html",
   "repository": "git@github.com:pusher/docs.git",


### PR DESCRIPTION
There is a potential packet/dependency confusion vulnerability (https://medium.com/@alex.birsan/dependency-confusion-4a5d60fec610) in the un-published `pusher-doc` package.
Using the `@pusher` namespace avoids the problem.