### PR TITLE
ensure docs correctly show client event data param is required

### DIFF
--- a/docs/channels/using_channels/events.md
+++ b/docs/channels/using_channels/events.md
@@ -419,7 +419,7 @@ channel.whisper(eventName, data);
 The name of the event to be triggered. A client event must have a name prefixed with `client-` or it will be rejected by the server.
 
 {% endparameter %}
-{% parameter 'data', 'Object', false, 'js' %}
+{% parameter 'data', 'Object', true, 'js' %}
 
 The object to be converted to JSON and distributed with the event.
 


### PR DESCRIPTION
Failing to provide the data param shows the error 
`Invalid client event (must contain channel, event and data)`

