### PR TITLE
Corrected int to string, and response key name

### DIFF
--- a/docs/channels/server_api/authenticating-users.md
+++ b/docs/channels/server_api/authenticating-users.md
@@ -51,7 +51,7 @@ app.use(express.urlencoded({ extended: false }));
 app.use(cors());
 app.post("/pusher/user-auth", (req, res) => {
   const socketId = req.body.socket_id;
-  const user = {id: 12345}; // Replace this with code to retrieve the actual user id
+  const user = {id: "12345"}; // Replace this with code to retrieve the actual user id
   const authResponse = pusher.authenticateUser(socketId, user);
   res.send(authResponse);
 });
@@ -89,7 +89,7 @@ if ( is_user_logged_in() ) {
 - **Unsuccessful** responses from an authentication endpoint should serve a `403 Forbidden` HTTP status.
 - **Successful** responses from an authentication endpoint should carry a `200 OK` HTTP status and a body of the form
   ```json
-  { "auth": "$AUTHORIZATION_STRING", "user_info": "$USER_INFO" }
+  { "auth": "$AUTHORIZATION_STRING", "user_data": "$USER_DATA" }
   ```
 ## Client-side: setting the authentication endpoint
 


### PR DESCRIPTION
https://pusher.com/docs/channels/server_api/authenticating-users/#user-authentication the code snippet incorrectly says:

`const user = {id: 12345}; // Replace this with code to retrieve the actual user id`

I've changed this to a string `id: "12345"` (The node lib will return 500 otherwise).

https://pusher.com/docs/channels/server_api/authenticating-users/#response should be user_data, not user_info. This has tripped up one person so far.

https://github.com/pusher/docs/issues/179