### PR TITLE
Use User Authentication info in Presence Channels

### DIFF
--- a/docs/channels/server_api/authenticating-users.md
+++ b/docs/channels/server_api/authenticating-users.md
@@ -26,7 +26,7 @@ When your client calls the `signin` method on a established conenction, the Chan
 
 You can start with an authentication endpoint that authenticates every request it receives. You can do that by copy-pasting one of the examples below. Note, however, that in order to make this useful, you'll have to change the example to use the actual user id and information of the correct user. The user object passed to the `authenticateUser` method must include an `id` field with a non-empty string. Other possible optional fields are:
 
-- `user_info` in which you can provide more information about the user (e.g. name). This information will be shared be shared with other members of presence channels that this user is authorized to join. Read more on that in [Presence Channels](/docs/channels/using_channels/presence-channels)
+- `user_info` in which you can provide more information about the user (e.g. name). This information will be shared with other members of presence channels that this user is authorized to join. Read more on that in [Presence Channels](/docs/channels/using_channels/presence-channels)
 
 If you don't see your language listed, you can [implement your own authentication endpoint](/docs/channels/library_auth_reference/auth-signatures) or [get in touch](https://pusher.com/support).
 

--- a/docs/channels/server_api/authenticating-users.md
+++ b/docs/channels/server_api/authenticating-users.md
@@ -24,7 +24,9 @@ We authenticate a user once per connection session. Authenticating a user gives 
 
 When your client calls the `signin` method on a established conenction, the Channels client library requests an authentication token from your server. By default, the Pusher Channels client library expects this endpoint to be at `/pusher/user-auth`, but this can be configured by the client.
 
-You can start with an authentication endpoint that authenticates every request it receives. You can do that by copy-pasting one of the examples below. Note, however, that in order to make this useful, you'll have to change the example to use the actual user id of the correct user. The user object passed to the `authenticateUser` method must include an `id` field with a non-empty string. Your server can also add more user data to the authentication token by adding other properties to the user object.
+You can start with an authentication endpoint that authenticates every request it receives. You can do that by copy-pasting one of the examples below. Note, however, that in order to make this useful, you'll have to change the example to use the actual user id and information of the correct user. The user object passed to the `authenticateUser` method must include an `id` field with a non-empty string. Other possible optional fields are:
+
+- `user_info` in which you can provide more information about the user (e.g. name). This information will be shared be shared with other members of presence channels that this user is authorized to join. Read more on that in [Presence Channels](/docs/channels/using_channels/presence-channels)
 
 If you don't see your language listed, you can [implement your own authentication endpoint](/docs/channels/library_auth_reference/auth-signatures) or [get in touch](https://pusher.com/support).
 
@@ -51,7 +53,14 @@ app.use(express.urlencoded({ extended: false }));
 app.use(cors());
 app.post("/pusher/user-auth", (req, res) => {
   const socketId = req.body.socket_id;
-  const user = {id: "12345"}; // Replace this with code to retrieve the actual user id
+  
+  // Replace this with code to retrieve the actual user id and info
+  const user = {
+    id: "12345",
+    user_info: {
+      name: "John Smith",
+    }
+  };
   const authResponse = pusher.authenticateUser(socketId, user);
   res.send(authResponse);
 });
@@ -63,7 +72,12 @@ app.listen(port);
 ```php
 global $user;
 if ($user->uid) {
-  $user_data = ['id' => (string) $user->uid];
+  $user_data = [
+    'id' => (string) $user->uid,
+    'user_info' => [
+      'name': $user->name,
+    ]
+  ];
   echo $pusher->authenticateUser($_POST['socket_id'], $user_data);
 } else {
   header('', true, 403);
@@ -73,7 +87,12 @@ if ($user->uid) {
 
 ```php
 if ( is_user_logged_in() ) {
-  $user_data = ['id' => (string) get_current_user_id()];
+  $user_data = [
+    'id' => (string) get_current_user_id(),
+    'user_info' => [
+        'name': (string) get_current_user()->name
+      ]
+    ];
   echo $pusher->authorizeChannel($_POST['socket_id'], $user_data);
 } else {
   header('', true, 403);
@@ -171,13 +190,15 @@ app.get("/pusher/user-auth", (req, res) => {
   const socketId = query.socket_id;
   const callback = query.callback;
 
-  const userInfo = {
+  const user = {
     id: "some_id",
-    name: "John Smith",
+    user_info: {
+      name: "John Smith",
+    }
   };
 
   const auth = JSON.stringify(
-    pusher.authenticateUser(socketId, userInfo)
+    pusher.authenticateUser(socketId, user)
   );
   const cb = callback.replace(/\\"/g,"") + "(" + auth + ");";
 

--- a/docs/channels/server_api/authorizing-users.md
+++ b/docs/channels/server_api/authorizing-users.md
@@ -34,8 +34,6 @@ Pusher Channels will only allow a connection to subscribe to a [private channel]
 
 You can start with an authorization endpoint that authorizes every request it receives. You can do that with [pusher-channels-auth-example](https://github.com/pusher/pusher-channels-auth-example) , or by copy-pasting one of the examples below. (If you don't see your language listed, you can [implement your own authorization endpoint](/docs/channels/library_auth_reference/auth-signatures) or [get in touch](https://pusher.com/support).)
 
-**User info in presence channels:**
-
 
 #### Implementing the authorization endpoint for a private channel
 

--- a/docs/channels/server_api/authorizing-users.md
+++ b/docs/channels/server_api/authorizing-users.md
@@ -21,7 +21,7 @@ This page discusses implementing a user authorization endpoint using the Pusher 
 >
 > We now support [User authentication](/docs/channels/server_api/authenticating-users) to extend this scheme and to add more functionality. We’ve made this backwards compatible with the old presence channel authorization mechanism, but we do encourage users to adopt the newer styles that will be used in future to add additional features.
 >
-> One of the results of using User Authentication is that providing user information in presence channel authorization is optional, if User Authentication already provides such information.
+> One of the results of using User Authentication is that providing the user object in presence channel authorization is optional, if the user is already signed-in using User Autentication.
 >
 > Note that in libraries that haven't been updated yet, the authorization function is still called `authenticate`.
 

--- a/docs/channels/server_api/authorizing-users.md
+++ b/docs/channels/server_api/authorizing-users.md
@@ -21,6 +21,8 @@ This page discusses implementing a user authorization endpoint using the Pusher 
 >
 > We now support [User authentication](/docs/channels/server_api/authenticating-users) to extend this scheme and to add more functionality. We’ve made this backwards compatible with the old presence channel authorization mechanism, but we do encourage users to adopt the newer styles that will be used in future to add additional features.
 >
+> One of the results of using User Authentication is that providing user information in presence channel authorization is optional, if User Authentication already provides such information.
+>
 > Note that in libraries that haven't been updated yet, the authorization function is still called `authenticate`.
 
 
@@ -31,6 +33,9 @@ Pusher Channels will only allow a connection to subscribe to a [private channel]
 ![Authorization Process](./img/private-channel-auth-process.png)
 
 You can start with an authorization endpoint that authorizes every request it receives. You can do that with [pusher-channels-auth-example](https://github.com/pusher/pusher-channels-auth-example) , or by copy-pasting one of the examples below. (If you don't see your language listed, you can [implement your own authorization endpoint](/docs/channels/library_auth_reference/auth-signatures) or [get in touch](https://pusher.com/support).)
+
+**User info in presence channels:**
+
 
 #### Implementing the authorization endpoint for a private channel
 

--- a/docs/channels/using_channels/presence-channels.md
+++ b/docs/channels/using_channels/presence-channels.md
@@ -15,10 +15,10 @@ Presence channels build on the security of Private channels and expose the addit
 
 Presence channels are subscribed to from the client API in the same way as [private channels](/docs/channels/using_channels/private-channels#subscribe) but the channel name must be prefixed with `presence-`. As with private channels a HTTP Request is made to a configurable authorization URL to determine if the current user has permissions to access the channel (see [Authorizing Users](/docs/channels/server_api/authorizing-users) ).
 
-Each member of the presence channel has a set of user information `user_info` that is shared with other members of the presence channel to identify this user. This information about the authorized user can come from two places:
+Each member of the presence channel has a user object containing the `id` of the user and a `user_info` field with more information about that user (e.g. name). That user object is shared with other members of the presence channel to identify this user. This user object can come from two places:
 
-- If the user is signed in with pusher by using the `signin` method on the client, the user information (`user_info`) provided during user authentication will be shared with other members in presence channels to identify this user. See more about providing `user_info` in [Authenticating Users](/docs/channels/server_api/authenticating-users).
-- You can always provide user information `user_info` during the authorization step of a presence channel which will override any user information coming from User Authentication.
+- If the user is signed in with pusher by using the `signin` method on the client, the user object provided during user authentication will be shared with other members in presence channels to identify this user. See more about providing the user object (`user_data`) in [Authenticating Users](/docs/channels/server_api/authenticating-users).
+- You can always provide the user object during the authorization step of a presence channel which will override the user object coming from User Authentication.
 
 Information on users subscribing to, and unsubscribing from a channel can then be accessed by [binding to events on the presence channel](/docs/channels/using_channels/presence-channels#events) and the current state of users subscribed to the channel is available via the <a href="/docs/channels/using_channels/presence-channels#accessing-channel-members"> <inlinecode>channel.members</inlinecode> property </a> .
 

--- a/docs/channels/using_channels/presence-channels.md
+++ b/docs/channels/using_channels/presence-channels.md
@@ -17,7 +17,7 @@ Presence channels are subscribed to from the client API in the same way as [priv
 
 Each member of the presence channel has a user object containing the `id` of the user and a `user_info` field with more information about that user (e.g. name). That user object is shared with other members of the presence channel to identify this user. This user object can come from two places:
 
-- If the user is signed in with pusher by using the `signin` method on the client, the user object provided during user authentication will be shared with other members in presence channels to identify this user. See more about providing the user object (`user_data`) in [Authenticating Users](/docs/channels/server_api/authenticating-users).
+- If the user is signed in with Pusher by using the `signin` method on the client, the user object provided during user authentication will be shared with other members in presence channels to identify this user. See more about providing the user object (`user_data`) in [Authenticating Users](/docs/channels/server_api/authenticating-users).
 - You can always provide the user object during the authorization step of a presence channel which will override the user object coming from User Authentication.
 
 Information on users subscribing to, and unsubscribing from a channel can then be accessed by [binding to events on the presence channel](/docs/channels/using_channels/presence-channels#events) and the current state of users subscribed to the channel is available via the <a href="/docs/channels/using_channels/presence-channels#accessing-channel-members"> <inlinecode>channel.members</inlinecode> property </a> .

--- a/docs/channels/using_channels/presence-channels.md
+++ b/docs/channels/using_channels/presence-channels.md
@@ -13,7 +13,12 @@ eleventyNavigation:
 
 Presence channels build on the security of Private channels and expose the additional feature of an **awareness of who is subscribed to that channel**. This makes it extremely easy to build chat room and "who's online" type functionality to your application. Think chat rooms, collaborators on a document, people viewing the same web page, competitors in a game, that kind of thing.
 
-Presence channels are subscribed to from the client API in the same way as [private channels](/docs/channels/using_channels/private-channels#subscribe) but the channel name must be prefixed with `presence-`. As with private channels a HTTP Request is made to a configurable authorization URL to determine if the current user has permissions to access the channel (see [Authorizing Users](/docs/channels/server_api/authorizing-users) ). The main difference is that within the response to the HTTP authorization request the developer can provide additional information about that user, which can then be used within your application.
+Presence channels are subscribed to from the client API in the same way as [private channels](/docs/channels/using_channels/private-channels#subscribe) but the channel name must be prefixed with `presence-`. As with private channels a HTTP Request is made to a configurable authorization URL to determine if the current user has permissions to access the channel (see [Authorizing Users](/docs/channels/server_api/authorizing-users) ).
+
+Each member of the presence channel has a set of user information `user_info` that is shared with other members of the presence channel to identify this user. This information about the authorized user can come from two places:
+
+- If the user is signed in with pusher by using the `signin` method on the client, the user information (`user_info`) provided during user authentication will be shared with other members in presence channels to identify this user. See more about providing `user_info` in [Authenticating Users](/docs/channels/server_api/authenticating-users).
+- You can always provide user information `user_info` during the authorization step of a presence channel which will override any user information coming from User Authentication.
 
 Information on users subscribing to, and unsubscribing from a channel can then be accessed by [binding to events on the presence channel](/docs/channels/using_channels/presence-channels#events) and the current state of users subscribed to the channel is available via the <a href="/docs/channels/using_channels/presence-channels#accessing-channel-members"> <inlinecode>channel.members</inlinecode> property </a> .
 


### PR DESCRIPTION
Introduce the possibility of providing `user_info` in User Authentication and how it affects Presence Channels.