### PR TITLE
Update channels documentation pages

### DIFF
--- a/docs/channels/pusher_cli/overview.md
+++ b/docs/channels/pusher_cli/overview.md
@@ -18,7 +18,7 @@ Pusher CLI is a tool that is designed to make your experience while developing P
 - List your Pusher apps as well as their tokens.
 - Subscribe to channels and see events
 - Trigger events on a given channel
-- Run a demo authorisation server (that by default just authorizes all clients!) to make debugging private channel using apps easier
+- Run a demo authorization server (that by default just authorizes all clients!) to make debugging private channel using apps easier
 - Generate client and server code with your keys prefilled.
 
 ## How do I get and use it?

--- a/docs/channels/server_api/authenticating-users.md
+++ b/docs/channels/server_api/authenticating-users.md
@@ -15,14 +15,14 @@ Pusher provides mechanisms for both authenticating and authorizing users. Our de
 
 Since your servers are the authority on who your users are, and what they can access, our [client libraries are able to make calls to endpoints of your choice](/docs/channels/using_channels/user-authentication) to supply signed authentication and authorization tokens for the bearing user.
 
-This page discusses implementing a user authentication endpoint using the Pusher Channels server libraries. If you're looking for information on implemeting a user authorization endpoint, check the [Authorizing users page](/docs/channels/server_api/authorizing-users).
+This page discusses implementing a user authentication endpoint using the Pusher Channels server libraries. If you're looking for information on implementing a user authorization endpoint, check the [Authorizing users page](/docs/channels/server_api/authorizing-users).
 
 
 ## User authentication
 
 We authenticate a user once per connection session. Authenticating a user gives your application access to user based features such as sending events to a user based on user id on terminating a user's connections immediately.
 
-When your client calls the `signin` method on a established conenction, the Channels client library requests an authentication token from your server. By default, the Pusher Channels client library expects this endpoint to be at `/pusher/user-auth`, but this can be configured by the client.
+When your client calls the `signin` method on a established connection, the Channels client library requests an authentication token from your server. By default, the Pusher Channels client library expects this endpoint to be at `/pusher/user-auth`, but this can be configured by the client.
 
 You can start with an authentication endpoint that authenticates every request it receives. You can do that by copy-pasting one of the examples below. Note, however, that in order to make this useful, you'll have to change the example to use the actual user id and information of the correct user. The user object passed to the `authenticateUser` method must include an `id` field with a non-empty string. Other possible optional fields are:
 
@@ -146,7 +146,7 @@ var pusher = new Pusher("app_key", {
 
 > Note that you should change the name of the CSRF token key to the convention you prefer.
 
-As an example, in Rails, you can inject the CSRF token into Javacript like this using ERB
+As an example, in Rails, you can inject the CSRF token into Javascript like this using ERB
 
 ```erb
 <script>

--- a/docs/channels/server_api/authorizing-users.md
+++ b/docs/channels/server_api/authorizing-users.md
@@ -15,13 +15,13 @@ Pusher provides mechanisms for both authenticating and authorizing users. Our de
 
 Since your servers are the authority on who your users are, and what they can access, our clients libraries are able to make callbacks to endpoints of your choice to supply signed authentication and authorization tokens for the bearing user.
 
-This page discusses implementing a user authorization endpoint using the Pusher Channels server libraries. If you're looking for information on implemeting a user authentication endpoint, check the [Authenticating users page](/docs/channels/server_api/authenticating-users).
+This page discusses implementing a user authorization endpoint using the Pusher Channels server libraries. If you're looking for information on implementing a user authentication endpoint, check the [Authenticating users page](/docs/channels/server_api/authenticating-users).
 
 > Pusher Channels originally supported pure authorization in private channels. With these authorization tokens it was not evident who the bearer was, but their token allowed them access to certain private channels. In presence channels, we added user info to the authorization token to provide extra information about who was connected (so that it could be distributed to other members of a channel). These tokens function as authentication and authorization within the scope of the presence channel.
 >
 > We now support [User authentication](/docs/channels/server_api/authenticating-users) to extend this scheme and to add more functionality. We’ve made this backwards compatible with the old presence channel authorization mechanism, but we do encourage users to adopt the newer styles that will be used in future to add additional features.
 >
-> One of the results of using User Authentication is that providing the user object in presence channel authorization is optional, if the user is already signed-in using User Autentication.
+> One of the results of using User Authentication is that providing the user object in presence channel authorization is optional, if the user is already signed-in using User Authentication.
 >
 > Note that in libraries that haven't been updated yet, the authorization function is still called `authenticate`.
 
@@ -106,7 +106,7 @@ app.use(cors());
 app.post("/pusher/auth", (req, res) => {
   const socketId = req.body.socket_id;
   const channel = req.body.channel_name;
-  const authReponse = pusher.authorizeChannel(socketId, channel);
+  const authResponse = pusher.authorizeChannel(socketId, channel);
   res.send(authResponse);
 });
 
@@ -364,11 +364,11 @@ The default value for this is `/pusher/auth`.
 
 {% conditionalContent 'objc', false %}
 
-In order to connect to a private or presence channel using libPusher, you first need to configure your server authorisation URL.
+In order to connect to a private or presence channel using libPusher, you first need to configure your server authorization URL.
 
 When you attempt to connect to a private or presence channel, libPusher will make a form-encoded POST request to the above URL, passing along the `socket_id` and `channel_name` as parameters. Prior to sending the request, the `PTPusherDelegate` will be notified. The delegate function is passed an `operation` parameter, which allows you to access the `NSMutableURLRequest` instance that will be sent.
 
-It is up to you to configure the request to handle whatever authentication mechanism you are using. In this example, we set a custom header with a token which the server will use to authenticate the user before proceeding with authorisation.
+It is up to you to configure the request to handle whatever authentication mechanism you are using. In this example, we set a custom header with a token which the server will use to authenticate the user before proceeding with authorization.
 
 ```objc
 - (void)pusher:(PTPusher *)pusher willAuthorizeChannel:(PTPusherChannel *)channel withAuthOperation:(PTPusherChannelAuthorizationOperation *)operation {
@@ -394,7 +394,7 @@ var pusher = new Pusher("app_key", {
 
 > Note that you should change the name of the CSRF token key to the convention you prefer.
 
-As an example, in Rails, you can inject the CSRF token into Javacript like this using ERB
+As an example, in Rails, you can inject the CSRF token into Javascript like this using ERB
 
 ```erb
 <script>

--- a/docs/channels/server_api/http-api.md
+++ b/docs/channels/server_api/http-api.md
@@ -20,7 +20,7 @@ Many of our libraries allow requests to be made asynchronously. Please consult t
 
 ## Publishing events
 
-Because it is such a fundamental part of the service, most of our libraries have special methods for triggering events. Behind the scenes this is just a simple call to our HTTP API. We recommend using serialised JSON to keep message sizes down.
+Because it is such a fundamental part of the service, most of our libraries have special methods for triggering events. Behind the scenes this is just a simple call to our HTTP API. We recommend using serialized JSON to keep message sizes down.
 
 Please bear in mind the following when publishing events:
 
@@ -799,7 +799,7 @@ For more information see the [pusher-http-php](https://github.com/pusher/pusher-
 {% endconditionalContent %}
 {% conditionalContent 'c', false %}
 
-The Channels Server library contains a specific wrapper that allows a consuming application to make a simple call specifying the type to deserialise to when making a GET request. `object` has been used above because as yet there isn't a defined class that the information can be serialized into.
+The Channels Server library contains a specific wrapper that allows a consuming application to make a simple call specifying the type to deserialize to when making a GET request. `object` has been used above because as yet there isn't a defined class that the information can be serialized into.
 
 For more information see the [pusher-http-dotnet](https://github.com/pusher/pusher-http-dotnet) README.
 
@@ -882,7 +882,7 @@ For more information see the [pusher-http-php](https://github.com/pusher/pusher-
 
 {% conditionalContent 'c', false %}
 
-The Channels Server library contains a specific wrapper that allows a consuming application to make a simple call specifying the type to deserialise to when requesting Channel Information.
+The Channels Server library contains a specific wrapper that allows a consuming application to make a simple call specifying the type to deserialize to when requesting Channel Information.
 
 For more information see the [pusher-http-dotnet](https://github.com/pusher/pusher-http-dotnet) README.
 

--- a/docs/channels/server_api/terminating-user-connections.md
+++ b/docs/channels/server_api/terminating-user-connections.md
@@ -32,7 +32,7 @@ $pusher->terminateUserConnections('user-id');
 {% endsnippets %}
 {% endmethodwrap %}
 
->Note that this will only terminate connections that have successfully completed the [user authentication flow](/docs/channels/server_api/authenticating-users). Connnections for users subscribed to presence channels but that have not been authenticated via this flow will not be terminated.
+>Note that this will only terminate connections that have successfully completed the [user authentication flow](/docs/channels/server_api/authenticating-users). Connections for users subscribed to presence channels but that have not been authenticated via this flow will not be terminated.
 
 ## Banning users
 

--- a/docs/channels/using_channels/encrypted-channels.md
+++ b/docs/channels/using_channels/encrypted-channels.md
@@ -1,7 +1,7 @@
 ---
 date: 2021-08-27
 title: Pusher Channels Docs | End-to-end Encryption
-description: The data published to E2EE channels is encrypted and cannot be read by any unauthorised party, including Pusher. E2EE channels also provide full authenticity.
+description: The data published to E2EE channels is encrypted and cannot be read by any unauthorized party, including Pusher. E2EE channels also provide full authenticity.
 layout: channels.njk
 eleventyNavigation:
   parent: Using channels
@@ -126,7 +126,7 @@ This feature hides the sensitive `data` field of your messages. However, by desi
 
 **Only Private channels are supported**
 
-Public and presence channels cannot currently be encrypted. Public channels will never support encryption, because by definition they carry only publically accessible data. If you have a use case for encryption of your data in presence channels, please let us know by contacting support.
+Public and presence channels cannot currently be encrypted. Public channels will never support encryption, because by definition they carry only publicly accessible data. If you have a use case for encryption of your data in presence channels, please let us know by contacting support.
 
 - **Channel names are not encrypted.**
   Pusher needs to inspect the message's channel name to determine which clients to send it to.
@@ -212,7 +212,7 @@ In order to rotate your encryption keys, change the master encryption key you pa
 
 Your clients will respond to any failure to decrypt an event by making one request per failed event to refresh their key. This is not guaranteed to work if you have multiple instances of your server running, because it will take some time for them to roll out. During the roll-out there may be a mix of keys in operation, for both encryption and decryption.
 
-During this period, clients may fail to decypt some events, even after requesting a new key (if, for example, that request is served by a server which is not yet updated). In this case, the client libraries provide a callback which you can register to be notified about events which failed.
+During this period, clients may fail to decrypt some events, even after requesting a new key (if, for example, that request is served by a server which is not yet updated). In this case, the client libraries provide a callback which you can register to be notified about events which failed.
 
 Once the key rotation is complete, all servers and clients will converge on the new keys, and events will flow without loss again.
 


### PR DESCRIPTION
Updated channels documentation pages for the sake of clarity and consistency by fixing typos and references. Closes #191.