### PR TITLE
remove line in snippet block

### DIFF
--- a/docs/channels/server_api/http-api.md
+++ b/docs/channels/server_api/http-api.md
@@ -585,7 +585,7 @@ var events = new List[]{
   new Event(){ EventName = "my-event-2", Channel = "my-channel-2", Data = "my name is bob" },
 }
 
-  ITriggerResult result = await pusher.TriggerAsync(events);
+ITriggerResult result = await pusher.TriggerAsync(events);
 ```
 
 ```js

--- a/docs/channels/server_api/http-api.md
+++ b/docs/channels/server_api/http-api.md
@@ -588,8 +588,6 @@ var events = new List[]{
   ITriggerResult result = await pusher.TriggerAsync(events);
 ```
 
-For more information see the [pusher-http-dotnet](https://github.com/pusher/pusher-http-dotnet) README.
-
 ```js
 const events = [
   {


### PR DESCRIPTION
This line `For more information see the [pusher-http-dotnet](https://github.com/pusher/pusher-http-dotnet) README.` is confusing the markdown snippet block and is showing this line in every snippet. Removing this.