### PR TITLE
Fix a syntax typo in react-native getting start doc

### DIFF
--- a/docs/channels/getting_started/react-native.md
+++ b/docs/channels/getting_started/react-native.md
@@ -56,7 +56,7 @@ let myChannel = await pusher.subscribe({
   channelName: "my-channel",
   onEvent: (event: PusherEvent) => {
     console.log(`onEvent: ${event}`);
-  };
+  }
 });
 ```
 


### PR DESCRIPTION
Just came across this when I was copying the snippet realized there's something wrong