### PR TITLE
add aps key to apns publish payload

### DIFF
--- a/docs/beams/reference/publish-payloads.md
+++ b/docs/beams/reference/publish-payloads.md
@@ -42,9 +42,11 @@ The full set of options for the APNs section of the `notify` call is described i
 ```js
 publishToUsers(["SOME_USER"], {
   apns: {
-    alert: {
-      title: "You have a new message",
-      body: "Hi!",
+    aps: {
+      alert: {
+        title: "You have a new message",
+        body: "Hi!",
+      }
     },
     data: {
       some: "metadata",


### PR DESCRIPTION
Correct a missing `aps` key to the example APNs payload